### PR TITLE
Extending Facebook spec

### DIFF
--- a/specs/fb.json
+++ b/specs/fb.json
@@ -41,6 +41,21 @@
             }
         },
         {
+            "path": ":id/likes",
+            "methods": [ "post" ],
+            "params": {
+                "access_token": "required"
+            }
+        },
+        {
+            "path": ":id/comments",
+            "methods": [ "post" ],
+            "params": {
+                "access_token": "required",
+                "message": "required"
+            }
+        },
+        {
             "path": ":id/picture",
             "methods": [ "get" ],
             "params": {

--- a/specs/fb.json
+++ b/specs/fb.json
@@ -37,7 +37,16 @@
             "params": {
                 "access_token": "required",
                 "message": "required",
-                "privacy": "optional"
+                "privacy": "optional",
+                "message": "optional",
+                "picture": "optional",
+                "link": "optional",
+                "name": "optional",
+                "caption": "optional",
+                "description": "optional",
+                "source": "optional",
+                "place": "optional",
+                "tags": "optional"
             }
         },
         {

--- a/specs/fb.json
+++ b/specs/fb.json
@@ -35,7 +35,6 @@
             "path": ":id/picture",
             "methods": [ "get" ],
             "params": {
-                "id": "required",
                 "type": "optional",
                 "width": "optional",
                 "height": "optional",

--- a/specs/fb.json
+++ b/specs/fb.json
@@ -16,6 +16,10 @@
             "methods": [ "get" ],
             "params": {
                 "q": "optional",
+                "type": "optional",
+                "center": "optional",
+                "distance": "optional",
+                "fields": "optional",
                 "access_token": "required"
             }
         },

--- a/specs/fb.json
+++ b/specs/fb.json
@@ -65,6 +65,17 @@
             }
         },
         {
+            "path": ":id/checkins",
+            "methods": [ "post" ],
+            "params": {
+                "access_token": "required",
+                "place": "required",
+                "coordinates": "optional",
+                "message": "optional",
+                "tags": "optional"
+            }
+        },
+        {
             "path": ":id/picture",
             "methods": [ "get" ],
             "params": {

--- a/specs/fb.json
+++ b/specs/fb.json
@@ -32,6 +32,15 @@
             }
         },
         {
+            "path": ":id/feed",
+            "methods": [ "post" ],
+            "params": {
+                "access_token": "required",
+                "message": "required",
+                "privacy": "optional"
+            }
+        },
+        {
             "path": ":id/picture",
             "methods": [ "get" ],
             "params": {

--- a/specs/fb.json
+++ b/specs/fb.json
@@ -79,6 +79,7 @@
             "path": ":id/picture",
             "methods": [ "get" ],
             "params": {
+                "id": "required",
                 "type": "optional",
                 "width": "optional",
                 "height": "optional",


### PR DESCRIPTION
I've added the following to the Facebook spec:
- More `optional` parameters to the `picture` path
- Removed an unnecessary parameter from the `search` path
- A `feed` path for publishing to a person's timeline
- Ability to like & comment on posts
- Ability to check in

Thanks for putting this cool project together!
