### PR TITLE
Return stream from request method

### DIFF
--- a/lib/unio.js
+++ b/lib/unio.js
@@ -140,7 +140,7 @@ Unio.prototype.request = function (verb, resource, params, callback) {
 
     // console.log('\nfinal reqOpts', util.inspect(reqOpts, true, 10, true))
 
-    request(reqOpts, function (err, res, body) {
+    return request(reqOpts, function (err, res, body) {
         // pass error to callback, or throw if no callback was passed in
         if (err) {
             if (validCallback)

--- a/test/unio.js
+++ b/test/unio.js
@@ -22,4 +22,11 @@ describe('unio behavior', function () {
 
         done()
     })
+
+    it('rest methods return a stream', function() {
+        client.use('twitter')
+        var stream = client.get('search/tweets', { q: 'banana' })
+
+        assert(typeof stream.pipe !== 'undefined')
+    })
 })


### PR DESCRIPTION
Adds the ability to pipe api responses in client apps by returning the `request` lib's stream object.
