### PR TITLE
Remove check for spec file existence before require()ing.

### DIFF
--- a/lib/unio.js
+++ b/lib/unio.js
@@ -69,10 +69,10 @@ Unio.prototype.spec = function (spec) {
     } else if (typeof spec === 'string') {
         //expects file on fs to be a json file
         //or js file exporting an object
-        if (fs.existsSync(spec)) {
+        try {
             spec = require(spec)
             return this.addSpec(spec)
-        } else {
+        } catch (e) {
             throw new Error('string argument passed to `unio.spec()` does not exist on the local fs')
         }
     } else {


### PR DESCRIPTION
Rely on require() to throw an error if the spec file can not be opened.
Because fs.existsSync() uses process.cwd() as a base when given a relative
path, if the user provides a path to client.spec() that is relative to unio.js
fs.existsSync() will return false.  If a path relative to process.cwd()
is provided fs.existsSync() will return true but require() will likely not
be able to find it and throw an error.

Also, as the file is not guaranteed to still exist by the time require()
is reached, the check doesn't provide any apparent value.
