### PR TITLE
Override request with options.request

### DIFF
--- a/lib/unio.js
+++ b/lib/unio.js
@@ -6,7 +6,11 @@ var querystring = require('querystring')
 var path = require('path')
 var helper = require('./helper')
 
-module.exports = function () {
+module.exports = function (options) {
+
+    options = options || {};
+    request = options.request || request;
+
     return new Unio()
 }
 
@@ -45,23 +49,23 @@ VERBS.forEach(function (verb) {
 
 /**
  * Import a new REST API spec into Unio
- * 
+ *
  * @param  {Object or String or Array} spec
  *
  * `spec` can be:
  *  (1) Object (single API spec)
  *  (2) Array (Array of (1))
  *  (3) String representing:
- *      -   local fs path to json file that 
+ *      -   local fs path to json file that
  *          is parsed as (1) or (2)
- *      
+ *
  */
 Unio.prototype.spec = function (spec) {
     var self = this
 
     if (Array.isArray(spec)) {
-        spec.forEach(function (entry) { 
-            self.addSpec(entry) 
+        spec.forEach(function (entry) {
+            self.addSpec(entry)
         })
         return this
     } else if (typeof spec === 'object') {
@@ -98,7 +102,7 @@ Unio.prototype.use = function (specName) {
 
 /**
  * Finalize and send the request, then pass control to `callback`.
- * 
+ *
  * @param  {String}   verb      http verb e.g. get, post
  * @param  {String}   resource  API resource e.g. search/tweets
  * @param  {Function} callback  completion callback. Signature: function (err, res, reply) {}
@@ -124,7 +128,7 @@ Unio.prototype.request = function (verb, resource, params, callback) {
     }
 
     // validate `params` against the currently used spec
-    
+
     Object.keys(specResource.params).forEach(function (keyName) {
         var isRequired = specResource.params[keyName] === 'required'
 
@@ -167,7 +171,7 @@ Unio.prototype.request = function (verb, resource, params, callback) {
 /**
  * Find the first matching API resource for `verb` and `resource`
  * from the spec we are currently using.
- * 
+ *
  * @param  {String} verb       HTTP verb; eg. 'get', 'post'.
  * @param  {String} resource   user's requested resource.
  * @return {Object}            matching resource object from the spec.
@@ -177,13 +181,13 @@ Unio.prototype.findMatchingResource = function (verb, resource) {
     var specResource = null
     var resourceCandidates = this.usingSpec.resources
 
-    // find the first matching resource in the spec, by 
+    // find the first matching resource in the spec, by
     // checking the name and then the path of each resource in the spec
     resourceCandidates.some(function (candidate, index) {
 
         var normName = candidate.name && self.normalizeUri(candidate.name)
         var normPath = candidate.path && self.normalizeUri(candidate.path)
-                                    
+
         var rgxName = new RegExp(normName)
         var rgxPath = new RegExp(normPath)
 
@@ -222,7 +226,7 @@ Unio.prototype.buildRequestOpts = function (verb, resource, specResource, params
         reqOpts.url = specResource.path
     } else {
 
-        var queryPath = specResource.path ? specResource.path : resource     
+        var queryPath = specResource.path ? specResource.path : resource
 
         // otherwise append the resource url fragment to the api root
         reqOpts.url = this.usingSpec.api_root + '/' + queryPath
@@ -265,7 +269,7 @@ Unio.prototype.buildRequestOpts = function (verb, resource, specResource, params
     }
 
     // encode the rest of the parameters as appropriate (querystring or body)
-    
+
     if ([ 'post', 'put', 'patch' ].indexOf(verb) !== -1) {
         reqOpts.body = self.urlEncode(paramsClone)
 
@@ -292,7 +296,7 @@ Unio.prototype.urlEncode = function (obj) {
 /**
  * Normalize `uri` string to its corresponding regex string.
  * Used for matching unio requests to the appropriate resource.
- * 
+ *
  * @param  {String} uri
  * @return {String}
  */

--- a/lib/unio.js
+++ b/lib/unio.js
@@ -8,10 +8,9 @@ var helper = require('./helper')
 
 module.exports = function (options) {
 
-    options = options || {};
-    request = options.request || request;
+    options = options || {}
 
-    return new Unio()
+    return new Unio(options)
 }
 
 // allowed verbs
@@ -23,10 +22,11 @@ var VERBS = [
     'delete'
 ];
 
-function Unio () {
+function Unio (options) {
     var self = this
 
     this.specs = {}
+    this.options = options
 
     // import specs from fs into unio
     var specDir = path.resolve(__dirname, '../specs')
@@ -144,28 +144,35 @@ Unio.prototype.request = function (verb, resource, params, callback) {
 
     // console.log('\nfinal reqOpts', util.inspect(reqOpts, true, 10, true))
 
-    return request(reqOpts, function (err, res, body) {
-        // pass error to callback, or throw if no callback was passed in
-        if (err) {
-            if (validCallback)
-                return callback(err, null)
+    var _request = self.options.request || function (options, callback) {
 
-            throw err
-        }
+        return request(options, function (err, res, body) {
+            // pass error to callback, or throw if no callback was passed in
+            if (err) {
+                if (validCallback)
+                    return callback(err, null)
 
-        var parsed = null
+                throw err
+            }
 
-        // attempt to parse the string as JSON
-        // if we fail, pass the callback the raw response body
-        try {
-            parsed = JSON.parse(body)
-        } catch (e) {
-            parsed = body
-        } finally {
-            if (validCallback)
-                return callback(null, res, parsed)
-        }
-    })
+            var parsed = null
+
+            // attempt to parse the string as JSON
+            // if we fail, pass the callback the raw response body
+            try {
+                parsed = JSON.parse(body)
+            } catch (e) {
+                parsed = body
+            } finally {
+                if (validCallback)
+                    return callback(null, res, parsed)
+            }
+        })
+
+    }
+
+    return _request(reqOpts, callback)
+
 }
 
 /**


### PR DESCRIPTION
Added small change to allow the local request dependency to be overridden, using an options object.

``` javascript
var customRequest = require('request');

var client = Unio({

     request: function (options, callback) {

        return customRequest(options, function (err, res, body) {

            // .. do something, maybe use callback

        });

     }

});
```
