### PR TITLE
Pass HTTP auth parameters through to Request

### DIFF
--- a/lib/unio.js
+++ b/lib/unio.js
@@ -258,8 +258,9 @@ Unio.prototype.buildRequestOpts = function (verb, resource, specResource, params
     // encode http auth params (if specified) and strip from `paramsClone`
     if (paramsClone.httpAuth) {
       var httpAuthClone = helper.clone(paramsClone.httpAuth)
-      reqOpts.auth = paramsClone.httpAuth;
-      delete paramsClone.httpAuth;
+      reqOpts.auth = paramsClone.httpAuth
+
+      delete paramsClone.httpAuth
     }
 
     // encode the oauth params (if specified) and strip from `paramsClone`

--- a/lib/unio.js
+++ b/lib/unio.js
@@ -255,6 +255,13 @@ Unio.prototype.buildRequestOpts = function (verb, resource, specResource, params
         return '/' + paramVal
     })
 
+    // encode http auth params (if specified) and strip from `paramsClone`
+    if (paramsClone.httpAuth) {
+      var httpAuthClone = helper.clone(paramsClone.httpAuth)
+      reqOpts.auth = paramsClone.httpAuth;
+      delete paramsClone.httpAuth;
+    }
+
     // encode the oauth params (if specified) and strip from `paramsClone`
     if (paramsClone.oauth) {
         // handle oauth info from params


### PR DESCRIPTION
Hi.  I have an API which uses basic HTTP auth for access.  I wanted to use Unio as a test and debugging client, but it didn't allow me to pass the auth options through to the request when sending.  I modified it, borrowing heavily from the oAuth parameter code just below the patch.
